### PR TITLE
Check more carefully for function call when rewriting

### DIFF
--- a/src/ComputedFieldTypes.jl
+++ b/src/ComputedFieldTypes.jl
@@ -21,7 +21,7 @@ macro computed(typeexpr::Expr)
 end
 
 "
-# the bulk of the work to 
+# the bulk of the work to
 "
 function _computed(typeexpr::Expr)
     typeexpr.head === :type || error("expected a type expression")
@@ -152,7 +152,7 @@ function rewrite_new!(e::Expr, tname::Symbol, decl_tvars, def)
 
         # rewrite constructor declarations to explicitly only involve the declared type-variables
         # this involves rewriting `A` as `(::Type{A{T}}){T}`
-        if (e.head === :(=) || e.head === :function) && e.args[1].head === :call
+        if e.head === :function || (e.head === :(=) && isa(e.args[1], Expr) && e.args[1].head === :call)
             pfname = e.args[1].args
             if isa(pfname[1], Expr) && pfname[1].head === :curly
                 pfname = pfname[1].args


### PR DESCRIPTION
I had a `ERROR: type Symbol has no field head` on expression
```julia
e = :(root = new{Ts, Tel, N, 2 ^ N}(splits))
```
with
```julia
@computed type BoxTree{Ts,Tel,N}
    splits::NTuple{N,Ts}
    parent::BoxTree{Ts,Tel,N}
    children::NTuple{2^N, BoxTree{Ts,Tel,N}}
    objs::Set{Tel}
    capacity::Int
    minwidth::NTuple{N,Ts}

    # Root node constructor
    function BoxTree{Ts,Tel,N}(splits::NTuple{N,Ts},
                               capacity=10,
                               minwidth=ntuple(d->zero(TS), Val{N})) where {Ts,Tel,N}
        root = new(splits)
        root.parent = root
        root.children = ntuple(d->root, 2^N)
        root.objs = Set{Tel}()
        root.capacity = capacity
        root.minwidth = minwidth
        root
    end
end
```
