### PR TITLE
fix `@computed` for types which inherit from an abstract type

### DIFF
--- a/src/ComputedFieldTypes.jl
+++ b/src/ComputedFieldTypes.jl
@@ -25,7 +25,7 @@ end
 "
 function _computed(typeexpr::Expr)
     typeexpr.head === :type || error("expected a type expression")
-    if typeexpr.args[2].head == :(<:)
+    if isa(typeexpr.args[2], Expr) && typeexpr.args[2].head == :(<:)
         curly = make_curly(typeexpr.args[2].args[1])
         typeexpr.args[2].args[1] = curly
     else

--- a/src/ComputedFieldTypes.jl
+++ b/src/ComputedFieldTypes.jl
@@ -81,6 +81,9 @@ end
 "
 make_curly(curly::ANY) = error("expected an apply-type expression")
 function make_curly(curly::Expr)
+    if curly.head == :(<:)
+        return make_curly(curly.args[1])
+    end
     if curly.head !== :curly || !isa(curly.args[1], Symbol)
         make_curly(nothing)
     end

--- a/src/ComputedFieldTypes.jl
+++ b/src/ComputedFieldTypes.jl
@@ -25,8 +25,13 @@ end
 "
 function _computed(typeexpr::Expr)
     typeexpr.head === :type || error("expected a type expression")
-    curly = make_curly(typeexpr.args[2])
-    typeexpr.args[2] = curly
+    if typeexpr.args[2].head == :(<:)
+        curly = make_curly(typeexpr.args[2].args[1])
+        typeexpr.args[2].args[1] = curly
+    else
+        curly = make_curly(typeexpr.args[2])
+        typeexpr.args[2] = curly
+    end
     tname = curly.args[1]::Symbol
 
     # extract list of declared type variables
@@ -81,9 +86,6 @@ end
 "
 make_curly(curly::ANY) = error("expected an apply-type expression")
 function make_curly(curly::Expr)
-    if curly.head == :(<:)
-        return make_curly(curly.args[1])
-    end
     if curly.head !== :curly || !isa(curly.args[1], Symbol)
         make_curly(nothing)
     end

--- a/test/inheritance.jl
+++ b/test/inheritance.jl
@@ -1,0 +1,25 @@
+module InheritanceTest
+using ComputedFieldTypes
+using Base.Test
+
+abstract type Bar end
+
+@computed struct Parametric{T} <: Bar
+    x::Base.promote_op(+, T, Float64)
+end
+
+@computed struct NonParametric <: Bar
+    x::Base.promote_op(+, Int, Float64)
+end
+
+@testset "inheritance" begin
+    @test isa(@inferred(Parametric{Int}(1)), Parametric{Int, Float64})
+    @test isa(Parametric{Int}(1), Bar)
+    @test isa(@inferred(Parametric{Float64}(1.0)), Parametric{Float64, Float64})
+
+    @test isa(@inferred(NonParametric(1)), NonParametric{Float64})
+    @test isa(NonParametric(1), Bar)
+end
+end
+
+

--- a/test/inheritance.jl
+++ b/test/inheritance.jl
@@ -12,6 +12,10 @@ end
     x::Base.promote_op(+, Int, Float64)
 end
 
+@computed struct NonParametricNoParent
+    x::Base.promote_op(+, Int, Float64)
+end
+
 @testset "inheritance" begin
     @test isa(@inferred(Parametric{Int}(1)), Parametric{Int, Float64})
     @test isa(Parametric{Int}(1), Bar)
@@ -19,6 +23,9 @@ end
 
     @test isa(@inferred(NonParametric(1)), NonParametric{Float64})
     @test isa(NonParametric(1), Bar)
+
+    @test isa(@inferred(NonParametricNoParent(1)), NonParametricNoParent{Float64})
+    @test !isa(NonParametricNoParent(1), Bar)
 end
 end
 

--- a/test/readme_examples.jl
+++ b/test/readme_examples.jl
@@ -1,0 +1,22 @@
+@computed type A{V <: AbstractVector}
+    a::eltype(V)
+end
+
+@testset "basic example" begin
+    a = A{Vector{Int}}(3.0)
+    @test a.a === Int(3)
+end
+
+@computed type B{N, M, T}
+    a::NTuple{N + M, T}
+    B(x::T) = new{N, M, T}(ntuple(i -> x, N + M))
+    B{S}(x::S) = B{N, M, T}(convert(T, x))
+end
+
+@computed type C{T <: Number}
+    a::typeof(one(T) / one(T))
+    C() = new(0)
+    function C(x)
+        return new(x)
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,12 +4,18 @@ using Base.Test
 
 abstract type Bar end
 
-@computed struct Foo{T} <: Bar
+@computed struct Parametric{T} <: Bar
     x::Base.promote_op(+, T, Float64)
 end
 
+@computed struct NonParametric <: Bar
+    x::Base.promote_op(+, Int, Float64)
+end
+
 @testset "inheritance" begin
-    @test isa(@inferred(Foo{Int}(1)), Foo{Int, Float64})
-    @test isa(@inferred(Foo{Float64}(1.0)), Foo{Float64, Float64})
+    @test isa(@inferred(Parametric{Int}(1)), Parametric{Int, Float64})
+    @test isa(@inferred(Parametric{Float64}(1.0)), Parametric{Float64, Float64})
+
+    @test isa(@inferred(NonParametric(1)), NonParametric{Float64})
 end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,21 +1,5 @@
-module InheritanceTest
 using ComputedFieldTypes
 using Base.Test
 
-abstract type Bar end
-
-@computed struct Parametric{T} <: Bar
-    x::Base.promote_op(+, T, Float64)
-end
-
-@computed struct NonParametric <: Bar
-    x::Base.promote_op(+, Int, Float64)
-end
-
-@testset "inheritance" begin
-    @test isa(@inferred(Parametric{Int}(1)), Parametric{Int, Float64})
-    @test isa(@inferred(Parametric{Float64}(1.0)), Parametric{Float64, Float64})
-
-    @test isa(@inferred(NonParametric(1)), NonParametric{Float64})
-end
-end
+include("readme_examples.jl")
+include("inheritance.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,0 +1,15 @@
+module InheritanceTest
+using ComputedFieldTypes
+using Base.Test
+
+abstract type Bar end
+
+@computed struct Foo{T} <: Bar
+    x::Base.promote_op(+, T, Float64)
+end
+
+@testset "inheritance" begin
+    @test isa(@inferred(Foo{Int}(1)), Foo{Int, Float64})
+    @test isa(@inferred(Foo{Float64}(1.0)), Foo{Float64, Float64})
+end
+end

--- a/travis.yml
+++ b/travis.yml
@@ -1,0 +1,16 @@
+language: julia
+julia:
+  - nightly
+  - 1.0
+os:
+  - linux
+branches:
+  only:
+    - master
+notifications:
+  email: false
+after_success:
+  - julia -e 'using Pkg;
+              Pkg.add("Coverage");
+              using Coverage;
+              Coveralls.submit(Coveralls.process_folder())'


### PR DESCRIPTION
Currently, trying to do:

```julia
@computed struct Foo <: Bar
  x::Int
end
```

fails with:

```
ERROR: LoadError: expected an apply-type expression
```

This PR fixes that issue and adds a test.