### PR TITLE
Fix dot head

### DIFF
--- a/src/ComputedFieldTypes.jl
+++ b/src/ComputedFieldTypes.jl
@@ -133,7 +133,7 @@ with a dummy type-variable
 """
 getenv!(@nospecialize(e), tvars, def) = e
 function getenv!(e::Expr, tvars, def)
-    if e.head === :curly || e.head === :where
+    if e.head === :curly || e.head === :where || e.head === :.
         for i = 1:length(e.args)
             e.args[i] = getenv!(e.args[i], tvars, def)
         end

--- a/test/inheritance.jl
+++ b/test/inheritance.jl
@@ -16,6 +16,13 @@ end
     x::Base.promote_op(+, Int, Float64)
 end
 
+struct Foo{T} x::T end
+
+@computed struct ParametricRef{T}
+    x::Base.RefValue{Foo{T}}
+    ParametricRef(x::Foo{T}) where T = new{T}(Ref(x))
+end
+
 @testset "inheritance" begin
     @test isa(@inferred(Parametric{Int}(1)), Parametric{Int, Float64})
     @test isa(Parametric{Int}(1), Bar)
@@ -26,7 +33,8 @@ end
 
     @test isa(@inferred(NonParametricNoParent(1)), NonParametricNoParent{Float64})
     @test !isa(NonParametricNoParent(1), Bar)
+
+    @test isa(@inferred(ParametricRef(Foo(1.0))), ParametricRef{Float64})
+    @test isa(ParametricRef(Foo(1)).x[], Foo{Int})
 end
 end
-
-


### PR DESCRIPTION
While working on this example (to bypass https://github.com/JuliaLang/julia/issues/18466), I encountered an issue using `Base.RefValue`:

```julia
using ComputedFieldTypes
import Base: RefValue

@computed struct Foo{T <: AbstractFloat, N}
  a::Array{T, N}
  b::Array{T, N + 1}
  Foo(a::Array{T, N}) where {T, N} = new{T, N}(a, zeros((2, size(a)...)))
end

struct Bar{T <: AbstractFloat, N}
  # r::RefValue{Foo{T, N}}  # obviously fails, but should it ? (fixed by ComputedFieldTypes.jl/pull/20)
  r::RefValue{Foo{T, N, 3}}  # works, but what's the point of using @computed then ? 
  Bar(r::Foo{T, N}) where {T, N} = new{T, N}(Ref(r))
end

@computed struct Baz{T <: AbstractFloat, N}
  r::Base.RefValue{Foo{T, N, N + 1}}  # <==== fails without this PR
  Baz(r::Foo{T, N}) where {T, N} = new{T, N}(Ref(r))
end

main() = begin
  foo = Foo([0. 1.])
  Bar(foo)
  Baz(foo)
  return
end

main()
```