### PR TITLE
Fix reference

### DIFF
--- a/test/multiple.jl
+++ b/test/multiple.jl
@@ -1,0 +1,31 @@
+module Dummy
+
+using ComputedFieldTypes
+import Base: RefValue
+using Test
+
+@computed struct Foo{T <: AbstractFloat, N}
+  a::Array{T, N}
+  b::Array{T, N + 1}
+  Foo(a::Array{T, N}) where {T, N} = new{T, N}(a, reshape(a, (size(a)..., 1)))
+end
+
+@computed struct Bar{T <: AbstractFloat, N}
+  r::RefValue{Foo{T, N}}
+  Bar(r::Foo{T, N}) where {T, N} = new{T, N}(Ref(r))
+end
+
+@computed struct Baz{T <: AbstractFloat, O}
+  r::RefValue{Foo{T, O}}
+  Baz(r::Foo{T, O}) where {T, O} = new{T, O}(Ref(r))
+end
+
+@testset "multiple" begin
+  m = Float64[0 1; 2 3]
+  foo = Foo(m)
+  @test ndims(foo.b) == ndims(m) + 1
+  @test ndims(Bar(foo).r[].b) == ndims(m) + 1
+  @test_throws MethodError ndims(Baz(foo).r[].b) == ndims(m) + 1  # FIXME
+end
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,3 +3,4 @@ using Test
 
 include("readme_examples.jl")
 include("inheritance.jl")
+include("multiple.jl")


### PR DESCRIPTION
Fixes the following example (mentioned in https://github.com/vtjnash/ComputedFieldTypes.jl/pull/19):

```julia
using ComputedFieldTypes
import Base: RefValue

@computed struct Foo{T <: AbstractFloat, N}
  a::Array{T, N}
  b::Array{T, N + 1}
  Foo(a::Array{T, N}) where {T, N} = new{T, N}(a, zeros((2, size(a)...)))
end

@computed struct Bar{T <: AbstractFloat, N}
  r::RefValue{Foo{T, N}}  # <==== fails without this PR
  Bar(r::Foo{T, N}) where {T, N} = new{T, N}(Ref(r))
end

main() = Bar(Foo([0. 1.]))

main()
```

EDIT: one limitation though, is that using `Foo{T, O}` instead of `Foo{T, N}` will fail (see the tests).