### PR TITLE
handle where clauses and computed {} heads better

### DIFF
--- a/test/inheritance.jl
+++ b/test/inheritance.jl
@@ -16,13 +16,6 @@ end
     x::Base.promote_op(+, Int, Float64)
 end
 
-struct Foo{T} x::T end
-
-@computed struct ParametricRef{T}
-    x::Base.RefValue{Foo{T}}
-    ParametricRef(x::Foo{T}) where T = new{T}(Ref(x))
-end
-
 @testset "inheritance" begin
     @test isa(@inferred(Parametric{Int}(1)), Parametric{Int, Float64})
     @test isa(Parametric{Int}(1), Bar)
@@ -33,8 +26,41 @@ end
 
     @test isa(@inferred(NonParametricNoParent(1)), NonParametricNoParent{Float64})
     @test !isa(NonParametricNoParent(1), Bar)
-
-    @test isa(@inferred(ParametricRef(Foo(1.0))), ParametricRef{Float64})
-    @test isa(ParametricRef(Foo(1)).x[], Foo{Int})
 end
+
+@computed struct ParametricRef{T}
+    x::Base.RefValue{Some{T}}
+    y::getfield(Base,:RefValue){Some{T}}
+    ParametricRef(x::Some{T}) where {T} = new{T}(Ref(x), Ref(x))
+end
+
+@computed struct ParametricWhere{T}
+    a::Pair{S, Some{T}} where S
+    b::Pair{S, Some{T}} where S<:typeassert(T,DataType)
+    c::Pair{S, Some{T}} where S>:(T::DataType)
+    d::Pair{S, Some{T}} where typeassert(T,DataType)<:S<:typeassert(T,DataType)
+    ## this is currently illegal, since we cannot determine when to compute identity(S):
+    # x::Pair{identity(S), Some{T}} where S
+    function ParametricWhere(x::Some{T}) where {T}
+        p = something(x) => x
+        return new{T}(p, p, p, p)
+    end
+end
+
+@testset "nested expressions" begin
+    @test isa(@inferred(ParametricRef(Some(1.0))), ParametricRef{Float64})
+    T = typeof(ParametricRef(Some(1)))
+    @test T === fulltype(ParametricRef{Int})
+    @test isa(ParametricRef(Some(1)).x[], Some{Int})
+    @test isa(ParametricRef(Some(1)).y[], Some{Int})
+
+    @test isa(@inferred(ParametricWhere(Some(1.0))), ParametricWhere{Float64})
+    T = typeof(ParametricWhere(Some(1)))
+    @test T === fulltype(ParametricWhere{Int})
+    @test fieldtype(T, :a) === Pair{S, Some{Int}} where S
+    @test fieldtype(T, :b) === Pair{S, Some{Int}} where S<:Int
+    @test fieldtype(T, :c) === Pair{S, Some{Int}} where S>:Int
+    @test fieldtype(T, :d) === Pair{S, Some{Int}} where Int<:S<:Int
+end
+
 end


### PR DESCRIPTION
While I do not recommend using computed type heads (since the resulting
expression typically introduces bugs into your program), the general
intent is to handle them here regardless.

In particular, the user could wrap them with a call to `identity()`, so
we are not preventing this from being used badly by handling them badly.

Improves #19