### PR TITLE
fix typo handling a field name

### DIFF
--- a/src/ComputedFieldTypes.jl
+++ b/src/ComputedFieldTypes.jl
@@ -79,7 +79,7 @@ function _computed(__module__::Module, typeexpr::Expr)
     fieldnames = Symbol[]
     for f in fields
         if isa(f, Symbol)
-            push!(fieldnames, f.args[1]::Symbol)
+            push!(fieldnames, f)
         elseif isa(f, Expr)
             if f.head === :(::) && isa(f.args[1], Symbol)
                 push!(fieldnames, f.args[1]::Symbol)


### PR DESCRIPTION
This is not tested. As expected, it is broken.